### PR TITLE
go to loginpage if no refresh token

### DIFF
--- a/Backend/src/Auth/userValidation.js
+++ b/Backend/src/Auth/userValidation.js
@@ -90,7 +90,7 @@ export async function validateLogin(msg, fastify) {
 		const onlineUsers = await getOnlineUsers(db);
 		for (const onlineUser of onlineUsers) {
 			if (onlineUser.id === user.id) {
-				return ({ error: 'You are already logged in!' });
+				return ({ error: 'You are already logged in! Try it again after 60sec' });
 			}
 		}
 	} catch (err) {

--- a/Frontend/src/ts/socketEvents.ts
+++ b/Frontend/src/ts/socketEvents.ts
@@ -43,8 +43,9 @@ export function startSocketListeners() {
 	// custom errors (for our error handling)
 	socket.on('server_error', (err: any) => {
 		console.error(err.code, ' ', err.reason);
-		customAlert("Something went wrong. Please try again.");
-	});
+		if (err.code != 'AUTH_NO_TOKEN')
+			customAlert("Something went wrong. Please try again.");
+	})
 }
 
 /*


### PR DESCRIPTION
When you open multiple incognito screens they have the same token and the program is doing weird what makes sense. I added a redirect to the login page when there is no valid token to refresh. This means that if one player logs out the other one also goes to the login page. I could't log out that player properly so he has to wait 60 sec. That is not our fault but it is a bit of cheating when you play incognito against yourself to manipulate the score ;) 

This are my thoughts, what do you think?

I also added an exception when you get the message from AUTH_NO_TOKEN to not show that there is something wrong to the user.